### PR TITLE
fix(build): pin to sqlite>=3.32.3 to unblock binder image build

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - rasterio
   - rio-stac
   - shapely
+  - sqlite>=3.32.3
   - pip:
     - haikunator
     - pypgstac[psycopg]==0.9.8


### PR DESCRIPTION
Pinning to sqlite>=3.32.3 fixes the repo2docker build error!

resolves #23